### PR TITLE
Added multi-line comments ( #[[some comment]] ) to syntax definition

### DIFF
--- a/CMakeEditor.JSON-tmLanguage
+++ b/CMakeEditor.JSON-tmLanguage
@@ -18,6 +18,11 @@
         }, 
         {
             "name": "comment", 
+            "begin": "\\#\\[\\[",
+            "end": "\\]\\]"
+        },
+        {
+            "name": "comment", 
             "match": "\\#.+"
         }
     ], 

--- a/CMakeEditor.tmLanguage
+++ b/CMakeEditor.tmLanguage
@@ -36,6 +36,14 @@
 			<string>invalid.deprecated</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>\#\[\[</string>
+			<key>end</key>
+			<string>\]\]</string>
+			<key>name</key>
+			<string>comment</string>
+		</dict>
+		<dict>
 			<key>match</key>
 			<string>\#.+</string>
 			<key>name</key>


### PR DESCRIPTION
Simply added multi-line comment to syntax definition.

![image](https://cloud.githubusercontent.com/assets/3949614/10161045/fcedb824-66a9-11e5-96fe-a0959a5b0663.png)
